### PR TITLE
⚡ update docs head meta description value

### DIFF
--- a/layouts/partials/docs/head.html
+++ b/layouts/partials/docs/head.html
@@ -20,7 +20,9 @@
     <meta name="robots" content="noindex">
     {{- end }}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="A Modern Documentation Theme for Hugo" />
+    {{- with .Description | default ($.Param "description") }}
+    <meta name="description" content="{{ . }}">
+    {{- end }}
     <meta name="keywords" content="Documentation, Hugo, Hugo Theme, Bootstrap" />
     <meta name="author" content="Colin Wilson - Lotus Labs" />
     <meta name="email" content="support@aigis.uk" />


### PR DESCRIPTION
### Changes

Set `<meta name="description"....>` tag for `/docs` pages to the front matter `description` value.

### Tests
- [x] Automated tests have been added

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
