### PR TITLE
🔥 remove extraneous HTML (fix for <h1> tag SERP)

### DIFF
--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -45,9 +45,7 @@
                                             <i class="material-icons title-icon me-2">{{- .Params.icon | default "article" }}</i>
                                             {{ end }}
                                             <h1 class="content-title mb-0">
-                                                <span class="title-text">
-                                                    {{ $currentPage.Title }}
-                                                </span>
+                                                {{ $currentPage.Title }}
                                                 {{ if .Draft }}
                                                     <span class="badge bg-default fs-6 mb-1 align-middle">DRAFT</span>
                                                 {{ end }}


### PR DESCRIPTION
### Changes

Remove unnecessary extraneous HTML from inside the title `<h1>` tag of content pages.  

### Tests
- [x] Automated tests have been added

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
