### PR TITLE
🔥 remove Prism autoloader language path config

### DIFF
--- a/assets/docs/js/prism.js
+++ b/assets/docs/js/prism.js
@@ -3768,4 +3768,4 @@ Prism.languages.js = Prism.languages.javascript;
 }());
 
 //Prism Autoloader Plugin Grammar Path
-Prism.plugins.autoloader.languages_path = '/docs/js/components/';
+// Prism.plugins.autoloader.languages_path = '/docs/js/components/';


### PR DESCRIPTION
### Changes

Fix for issue discovered via discussion https://github.com/colinwilson/lotusdocs/discussions/77

PrismJS: Remove hardcoded language grammar path in `prism.js`


### Tests
- [x] Automated tests have been added

<!-- ### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change -->

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
