### PR TITLE
🐛 fix PrismJS autoloader path issue #78

### DIFF
--- a/assets/docs/js/prism.js
+++ b/assets/docs/js/prism.js
@@ -1,5 +1,6 @@
 /* PrismJS 1.29.0
 https://prismjs.com/download.html#themes=prism-tomorrow&languages=markup+css+clike+javascript+diff&plugins=line-highlight+line-numbers+file-highlight+autoloader+normalize-whitespace+toolbar+copy-to-clipboard+treeview */
+import params from "@params";
 /// <reference lib="WebWorker"/>
 
 var _self = (typeof window !== 'undefined')
@@ -2876,7 +2877,7 @@ Prism.languages.js = Prism.languages.javascript;
 	var lang_data = {};
 
 	var ignored_language = 'none';
-	var languages_path = 'components/';
+	var languages_path = params.langPath;
 
 	var script = Prism.util.currentScript();
 	if (script) {
@@ -3766,6 +3767,3 @@ Prism.languages.js = Prism.languages.javascript;
 		}
 	});
 }());
-
-//Prism Autoloader Plugin Grammar Path
-// Prism.plugins.autoloader.languages_path = '/docs/js/components/';

--- a/layouts/partials/docs/footer/footer-scripts.html
+++ b/layouts/partials/docs/footer/footer-scripts.html
@@ -29,7 +29,10 @@
 
 {{ if eq .Site.Params.docs.prism true -}}
     {{ $prism := resources.Get (printf "/%s/%s" ($.Scratch.Get "pathName") "js/prism.js") }}
-    {{ $prism := $prism | js.Build -}}
+    {{- $opts := dict
+        "params" (dict "langPath" (urls.JoinPath .Site.BaseURL "docs/js/components/"))
+    -}}
+    {{ $prism := $prism | js.Build $opts -}}
     {{ $slice = $slice | append $prism -}}
 {{ end -}}
 


### PR DESCRIPTION
### Changes

Fix for #78 . Previous 'fix' caused PrismJS autoloader to (erroneously) look for language grammars relative to the current site path.

### Tests
- [x] Automated tests have been added

<!-- ### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change -->

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
