### PR TITLE
Add support for both small and big logos on the frontpage

### DIFF
--- a/assets/scss/custom/structure/_topbar.scss
+++ b/assets/scss/custom/structure/_topbar.scss
@@ -27,6 +27,25 @@
         &:focus {
             outline: none;
         }
+        
+        .small {
+            height: 31px;
+            display: none;
+            @media (max-width: 460px) {
+                display: inline-block;
+            }
+        }
+        .big {
+            height: 31px;
+            display: none;
+        
+            @media (min-width: 461px) {
+                display: inline-block;
+            }
+        }
+
+
+
     }
     #navigation {
         &.toggle-menu {

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,9 +3,16 @@
     <div class="container d-flex justify-content-between align-items-center">
         <!-- Logo container-->
         <a class="logo" aria-label="Home" href='{{ relLangURL "" }}'>
-            {{ with resources.Get "images/logos/mark.svg" }}
-                {{ .Content | safeHTML }}
-            {{ end }}
+            <div class="small">
+                {{ with resources.Get "images/logos/mark.svg" }}
+                        {{ .Content | safeHTML }}
+                {{ end }}
+            </div>
+            <div class="big">
+                {{ with resources.Get "images/logos/logo.svg" }}
+                        {{ .Content | safeHTML }}
+                {{ end }}
+            </div>
         </a>
         <!-- End Logo container-->
 


### PR DESCRIPTION
### Changes

I was checking how to add custom logo to the site and documented that down in https://github.com/colinwilson/lotusdocs.dev/pull/214.

This PR adds similiar support for the smaller `mark.svg` and bigger `logo.svg` files and fixes the styling for them.

CSS is definitely not my strong suite and feel free to make/suggest changes here.

<!-- ### Tests
- [ ] Automated tests have been added
- [] This PR does not require tests -->

<!-- ### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change -->

### Documentation
- [x] [Docs](https://github.com/colinwilson/lotusdocs.dev) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
