### PR TITLE
Fix flexsearch param

### DIFF
--- a/layouts/partials/docs/footer/flexsearch.html
+++ b/layouts/partials/docs/footer/flexsearch.html
@@ -121,7 +121,7 @@
 
     {{ $list := slice }}
     {{- if and (isset .Site.Params.flexsearch "searchsectionsindex") (not (eq (len .Site.Params.flexsearch.searchSectionsIndex) 0)) }}
-        {{- if eq .Site.Params.docs.searchSectionsIndex "ALL" }}
+        {{- if eq .Site.Params.flexsearch.searchSectionsIndex "ALL" }}
             {{- $list = .Site.Pages }}
         {{- else }}
             {{- $list = (where .Site.Pages "Type" "in" .Site.Params.flexsearch.searchSectionsIndex) }}


### PR DESCRIPTION
### Changes

wrong use of `.Site.Params.docs.searchSectionsIndex`, replace it by `.Site.Params.flexsearch.searchSectionsIndex`

<!-- ### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests -->

<!-- ### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change -->

<!-- ### Documentation
- [ ] [Docs](https://github.com/colinwilson/lotusdocs.dev) have been updated
- [ ] This change does not need a documentation update -->

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
