### PR TITLE
fix: Use or in partial

### DIFF
--- a/layouts/partials/docs/gitinfo.html
+++ b/layouts/partials/docs/gitinfo.html
@@ -18,7 +18,7 @@
 {{ $repoURL = delimit $repoURL "/" }}
 {{ $editPageURL := replaceRE "(https?://)|(/)+" "$1$2" $repoURL }}
 
-<div class="gitinfo d-flex flex-wrap justify-content-between align-items-center opacity-85 {{ if and .Site.Params.docs.lastMod .Site.Params.docs.editPage -}}pt-3{{ else }}visually-hidden{{ end }}">
+<div class="gitinfo d-flex flex-wrap justify-content-between align-items-center opacity-85 {{ if or .Site.Params.docs.lastMod .Site.Params.docs.editPage -}}pt-3{{ else }}visually-hidden{{ end }}">
     {{ if .Site.Params.docs.editPage | default false -}}
     <div id="edit-this-page" class="mt-1">
         <a href="{{ $editPageURL }}" alt="{{ .Title }}" rel="noopener noreferrer" target="_blank">


### PR DESCRIPTION
### Changes

The gitinfo template should use an OR instead of an AND for the checks on `lastMod` and `editPage`
The contents of the main div already had an exist check, so it already supports ui logic for showing one or both.
However the AND used in the class attribute forced the use of both  `lastMod` and `editPage`

<!-- ### Tests
- [ x ] This PR does not require tests -->

<!-- ### Changelog
- [ x ] This PR does not make a user-facing change -->

<!-- ### Documentation
- [ x ] This change does not need a documentation update -->

### Dark mode
- [ x ] The UI has been tested both in dark and light mode-->
