### PR TITLE
Allow to add noindex meta tag via frontmatter

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,6 +3,8 @@
     <title>{{- .Site.Title }}</title>
     {{- if not hugo.IsProduction }}
     <meta name="robots" content="noindex">
+    {{- else if .Params.noindex }}
+    <meta name="robots" content="noindex">
     {{- end }}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="A Lightweight, Modern Documentation Theme for Hugo" />


### PR DESCRIPTION
### Changes

This allows to set `noindex: true` via frontmatter.

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
