### PR TITLE
Support Version/Language dropdown menu & custom CSS/JS support

### DIFF
--- a/assets/docs/scss/style.scss
+++ b/assets/docs/scss/style.scss
@@ -72,3 +72,7 @@ $code-block-padding-top: {{ if eq .Site.Params.docs.prism true -}}0{{ else }}1.2
 
 // Mermaid
 @import "custom/plugins/mermaid/mermaid";
+
+.dropdown-item {
+   text-align: left !important;
+}

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -44,6 +44,7 @@
                                         </div>
                                         {{ end -}}
                                         <div class="docs-content col-12 {{ if .IsNode }}{{ else }}{{ if site.Params.docs.toc | default true }}{{ if and (ne .Params.toc false) (ne .TableOfContents "<nav id=\"TableOfContents\"></nav>") }}col-xl-9{{else}}{{end}}{{ else }}{{ end }}{{ end }} mt-0">
+                                            {{- partial (printf "%s/%s" ($.Scratch.Get "pathName") "version-banner.html") . }}
                                             <div class="mb-0 d-flex">
                                                 {{ if site.Params.docs.titleIcon | default false }}
                                                 <i class="material-icons title-icon me-2">{{- .Params.icon | default "article" }}</i>

--- a/layouts/partials/docs/head.html
+++ b/layouts/partials/docs/head.html
@@ -63,6 +63,15 @@
         {{- $style = $style | minify | fingerprint "sha384" }}
     {{- end -}}
     <link rel="stylesheet" href="{{ $style.RelPermalink }}" {{ if hugo.IsProduction }}integrity="{{ $style.Data.Integrity }}"{{ end -}} crossorigin="anonymous">
+    {{ range .Site.Params.docCustomCss -}}
+        <link rel="stylesheet" href="{{ . | absURL }}"/>
+    {{- end }}
+
+    <!-- Custom JS -->
+    {{ range .Site.Params.docCustomJs -}}
+        <script src="{{ . | absURL }}"></script>
+    {{- end }}
+
     <!-- Katex CSS -->
     {{- if .Params.katex -}}
     {{- $options := dict "enableSourceMap" true }}

--- a/layouts/partials/docs/i18nlist.html
+++ b/layouts/partials/docs/i18nlist.html
@@ -1,21 +1,8 @@
 {{ $pageLang := .Page.Lang }}
 {{ $translations := slice }}
-{{ $docspath := $.Scratch.Get "pathName" }}
 
 <!-- List available translations (excluding current page)-->
 {{ range .Translations }}
     <!-- Create 'available translations' slice -->
-    {{ $translations = $translations | append .Lang }}
     <li><a class="dropdown-item" href="{{ .RelPermalink }}" role="button" rel="alternate" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .Language.LanguageName }}</a></li>
-{{ end }}
-
-<!-- List of configured languages without a translation for the current page (link to doc root) -->
-{{ range .Site.Languages }}
-    {{ if ne $pageLang .Lang }}
-        <!-- If .Lang is in the 'available translations' slice, ignore it -->
-        {{ if in $translations .Lang }}
-        {{ else }}
-            <li><a class="dropdown-item" href="{{ .Lang | relURL }}/{{ $docspath }}" role="button" rel="alternate" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .LanguageName }}</a></li>
-        {{ end }}
-    {{ end }}
 {{ end }}

--- a/layouts/partials/docs/navbar-version.html
+++ b/layouts/partials/docs/navbar-version.html
@@ -1,0 +1,11 @@
+{{ $path := .Page.RelPermalink -}}
+
+{{ range .Site.Params.versions }}
+    {{ $url := $path -}}
+    {{ if ne .url "" -}}
+      {{ $url = (printf "%s/%s" (strings.TrimSuffix "/" .url) (strings.TrimPrefix "/" $path) ) -}}
+    {{ end -}}
+    {{ if not .current -}}
+    <li><a class="dropdown-item" href="{{ $url }}">{{ .version }}</a></li>
+    {{ end }}
+{{ end }}

--- a/layouts/partials/docs/top-header.html
+++ b/layouts/partials/docs/top-header.html
@@ -46,6 +46,21 @@
         </div>
 
         <div class="d-flex align-items-center">
+            {{ if .Site.Params.versions }}
+                <div class="dropdown">
+                    <button class="btn btn-link btn-default dropdown-toggle ps-2" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                        {{ range .Site.Params.versions }}
+                            {{ if .current -}}
+                                {{ .version -}}
+                                {{ break }}
+                            {{ end -}}
+                        {{ end }}
+                    </button>
+                    <ul class="dropdown-menu text-end">
+                        {{ partial (printf "%s/%s" ($.Scratch.Get "pathName") "navbar-version") . }}
+                    </ul>
+                </div>
+            {{ end }}
             <ul class="list-unstyled mb-0">
                 {{ with $.Scratch.Get "social_list" }}
                 {{ range . }}

--- a/layouts/partials/docs/top-header.html
+++ b/layouts/partials/docs/top-header.html
@@ -46,6 +46,16 @@
         </div>
 
         <div class="d-flex align-items-center">
+            {{ if .Site.IsMultiLingual }}
+                <div class="dropdown">
+                    <button class="btn btn-link btn-default dropdown-toggle ps-2" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                        {{ site.Language.LanguageName }}
+                    </button>
+                    <ul class="dropdown-menu text-end">
+                        {{ partial (printf "%s/%s" ($.Scratch.Get "pathName") "i18nlist") . }}
+                    </ul>
+                </div>
+            {{ end }}
             {{ if .Site.Params.versions }}
                 <div class="dropdown">
                     <button class="btn btn-link btn-default dropdown-toggle ps-2" type="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -93,16 +103,6 @@
                 </span>
             </button>
             {{ end -}}
-            {{ if .Site.IsMultiLingual }}
-                <div class="dropdown">
-                    <button class="btn btn-link btn-default dropdown-toggle ps-2" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-                        {{ site.Language.Lang | upper }}
-                    </button>
-                    <ul class="dropdown-menu text-end">
-                        {{ partial (printf "%s/%s" ($.Scratch.Get "pathName") "i18nlist") . }}
-                    </ul>
-                </div>
-            {{ end }}
         </div>
     </div>
     <!-- FlexSearch Input Start -->

--- a/layouts/partials/docs/version-banner.html
+++ b/layouts/partials/docs/version-banner.html
@@ -1,0 +1,37 @@
+{{ $latestVersionUrl := urls.Parse $.Site.Params.Baseurl }}
+{{ $currentVersion := "" }}
+
+{{ range .Site.Params.versions }}
+    {{ if .current -}}
+      {{ $currentVersion = .version }}
+      {{ break }}
+    {{ end -}}
+{{ end }}
+
+{{ if .Site.Params.versionInfo.archived }}
+  <br/>
+  <div class="alert alert-danger d-flex" role="alert">
+    <div class="flex-shrink-1 alert-icon">
+
+    <span class="material-icons size-20 me-2">
+    report
+    </span></div>
+
+    <div class="w-100">
+      <p>Version <strong>{{ $currentVersion | markdownify }}</strong> documentation is <strong>no longer actively maintained</strong>. The version you are currently viewing is an archived snapshot. For up-to-date information, see the <a href="{{ $latestVersionUrl | safeURL }}" target="_blank"><strong>latest version</strong></a>.</p>
+    </div>
+  </div>
+{{ else if .Site.Params.versionInfo.unreleased }}
+  <br/>
+  <div class="alert alert-warning d-flex" role="alert">
+    <div class="flex-shrink-1 alert-icon">
+
+    <span class="material-icons size-20 me-2">
+    warning
+    </span></div>
+
+    <div class="w-100">
+      <p>Version <strong>{{ $currentVersion | markdownify }}</strong> documentation is <strong>unreleased and frequently changed</strong>. For up-to-date information, see the <a href="{{ $latestVersionUrl | safeURL }}" target="_blank"><strong>latest version</strong></a>.</p>
+    </div>
+  </div>
+{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -26,6 +26,9 @@
         {{- $style = $style | minify | fingerprint "sha384" }}
     {{- end -}}
     <link rel="stylesheet" href="{{ $style.RelPermalink }}" {{ if hugo.IsProduction }}integrity="{{ $style.Data.Integrity }}"{{ end -}}/>
+    {{ range .Site.Params.customCss -}}
+        <link rel="stylesheet" href="{{ . | absURL }}"/>
+    {{- end }}
     <!-- Bootstrap JS -->
     {{ $js := resources.Get "js/bootstrap.js" }}
     {{ $params := dict }}
@@ -35,7 +38,13 @@
     {{ if hugo.IsProduction }}
         {{ $js = $js | fingerprint "sha384" }}
     {{ end }}
-        <script src="{{ $js.RelPermalink }}" {{ if hugo.IsProduction }}integrity="{{ $js.Data.Integrity }}"{{ end -}} defer></script>
+    <script src="{{ $js.RelPermalink }}" {{ if hugo.IsProduction }}integrity="{{ $js.Data.Integrity }}"{{ end -}} defer></script>
+
+    <!-- Custom JS -->
+    {{ range .Site.Params.customJs -}}
+        <script src="{{ . | absURL }}"></script>
+    {{- end }}
+
     <!-- Image Compare Viewer -->
     {{ if ($.Scratch.Get "image_compare_enabled") }}
         {{ $imagecompare := resources.Get "js/image-compare-viewer.min.js" }}


### PR DESCRIPTION
### Changes

Please describe the changes made in the pull request here.

This PR aims to add useful features, include

* Version dropdown menu
  * This implementation redirects user to any URL user specific, for example `https://v0-2.lotusdocs.dev/`, and user is responsible to add new DNS and hosting a site for out-of-date docs.
* Version warning banner
* Multilingual mode & dropdown menu
* Custom JS/CSS

Version dropdown menu

![Screenshot 2024-01-08 at 12 54 52 PM](https://github.com/colinwilson/lotusdocs/assets/202578/6e661891-5e20-4453-8e2a-b04c1034dc92)

Multilingual mode

![Screenshot 2024-01-08 at 12 54 56 PM](https://github.com/colinwilson/lotusdocs/assets/202578/5e8b4045-aef0-4f49-885a-ccd1d37a5707)

Banner for archived doc

![Screenshot 2024-01-08 at 12 55 26 PM](https://github.com/colinwilson/lotusdocs/assets/202578/e993667c-8988-443b-af76-61b9345deb5e)

Banner for unreleased doc

![Screenshot 2024-01-08 at 12 55 50 PM](https://github.com/colinwilson/lotusdocs/assets/202578/4e5c2d8b-e556-4215-af3e-7ff9f394aee3)

To enable these features, following config must be add to `hugo.toml`

```
defaultContentLanguage = 'en'
defaultContentLanguageInSubdir = true

[languages]
  [languages.en]
    contentDir = 'content/en'
    disabled = false
    languageCode = 'en-US'
    languageDirection = 'ltr'
    languageName = 'English'
    title = 'Project Documentation'
    weight = 2
    [languages.en.params]
      subtitle = 'Reference, Tutorials, and Explanations'

  [languages.zh-hant]
    contentDir = 'content/zh-hant'
    disabled = false
    languageCode = 'zh-Hant'
    languageDirection = 'ltr'
    languageName = '正體中文'
    title = 'Project Documentation'
    weight = 2
    [languages.zh-hant.params]
      subtitle = 'Reference, Tutorials, and Explanations'

[params]

  # CSS/JS for home page
  customCss = [] 
  customJs = []

  # CSS/JS for doc pages
  docCustomCss = ["css/custom.css"]
  docCustomJs = []

[params.versionInfo]
  dropdownMenuText = "Releases"
  archived = false                     # indicate this is an archived doc set branch and display warning banner - default false
  unreleased = true                   # indicate this is an unreleased doc set branch and display warning banner - default false

[[params.versions]]
  version = "Nightly"
  url = "https://nightly.lotusdocs.dev/"

[[params.versions]]
  version = "v0.1.0"
  current = true                       # display as current branch version

[[params.versions]]
  version = "v0.0.0"
  url = "https://v0-1.lotusdocs.dev/"
```

For `Multilingual`, language specific documentation must be placed in the `content/<lang>/docs`, like the following

![Screenshot 2024-01-08 at 12 59 12 PM](https://github.com/colinwilson/lotusdocs/assets/202578/5ebb1178-ec3a-4e11-b894-51fe1c55b033)

To add custom CSS/JS, you must place files under `static/css` & `static/js`. For example, I add `custom.css` and the `hugo.toml` I've used is 

```
  docCustomCss = ["css/custom.css"]
  docCustomJs = []
```

Below you'll find a checklist. For each item on the list, check one option and delete the other.

<!-- ### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests -->

<!-- ### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change -->

<!-- ### Documentation
- [ ] [Docs](https://github.com/colinwilson/lotusdocs.dev) have been updated
- [ ] This change does not need a documentation update -->

### Dark mode
- [ V ] The UI has been tested both in dark and light mode
- [ X ] This PR does not change the UI
