### PR TITLE
fix URL in CTA button

### DIFF
--- a/layouts/partials/landing/hero.html
+++ b/layouts/partials/landing/hero.html
@@ -62,7 +62,7 @@
 
                     <div class="mt-3">
                         {{ with .ctaButton }}
-                            <a href="{{ relLangURL .Site.Data.landing.hero.ctaButton.url }}" class="btn btn-lg btn-primary me-2 mt-2">
+                            <a href="{{ relLangURL .url }}" class="btn btn-lg btn-primary me-2 mt-2">
                                 {{ with .icon }}
                                     <span class="material-icons align-middle">{{ . }}</span>
                                 {{ end }}


### PR DESCRIPTION
### Changes

This is a very small, one-line fix to address an issue mentioned in #143. Currently, the ctaButton button always leads to root, regardless of the `ctaButton.url` setting.

This change correctly links the ctaButton's destination to the URL set in landing.yaml.

<!-- ### Tests
- [X] This PR does not require tests -->

<!-- ### Changelog
- [X] This PR does not make a user-facing change -->

<!-- ### Documentation
- [X] This change does not need a documentation update -->

### Dark mode
- [X] This PR does not change the UI
