### PR TITLE
Fix error messages when running example site with hugo 0.138

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Check out the demo site [https://lotusdocs.dev/docs/](https://lotusdocs.dev/docs
 
 ### Requirements
 
-- Hugo **Extended** (minimum version: 0.124.0)
+- Hugo **Extended** (minimum version: 0.140.0)
 - git
-- Go (minimum version v1.20)
+- Go (minimum version v1.21)
 
 ### Initialize your site as a Hugo Module
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Check out the demo site [https://lotusdocs.dev/docs/](https://lotusdocs.dev/docs
 
 ### Requirements
 
-- Hugo **Extended** (minimum version: 0.120.0)
+- Hugo **Extended** (minimum version: 0.124.0)
 - git
 - Go (minimum version v1.20)
 

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 [module]
   [module.hugoVersion]
     extended = true
-    min = "0.120.0"
+    min = "0.124.0"
   [[module.imports]]
     path = "github.com/gohugoio/hugo-mod-bootstrap-scss/v5"
     disable = false

--- a/exampleSite/content/docs/example-content/mermaid.md
+++ b/exampleSite/content/docs/example-content/mermaid.md
@@ -34,7 +34,7 @@ John->>Bob: How about you?
 Bob-->>John: Jolly good!
 ```
 
-## Gnatt Chart
+## Gantt Chart
 
 ```mermaid
 gantt

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -1,6 +1,6 @@
 module github.com/colinwilson/lotusdocs/exampleSite
 
-go 1.19
+go 1.21
 
 require (
 	github.com/colinwilson/lotusdocs v0.0.0-20230915145608-8bab2d130c1e // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/colinwilson/lotusdocs
 
-go 1.19
+go 1.21

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -40,7 +40,7 @@ If so, collect and consolidate the items config from each enabled instance
 
         <!-- Lotus Docs JS -->
         {{ $app := resources.Get "/js/app.js" }}
-        {{- if not .Site.IsServer }}
+        {{- if not hugo.IsServer }}
             {{- $js := (slice $app) | resources.Concat "/js/bundle.js" | minify | fingerprint "sha384" }}
             <script type="text/javascript" src="{{ $js.Permalink }}" integrity="{{ $js.Data.Integrity }}"></script>
         {{- else }}

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -16,7 +16,7 @@
                 {{- partial (printf "%s/%s" ($.Scratch.Get "pathName") "sidebar.html") . -}}
                     <!-- Start Page Content -->
                     <main class="page-content bg-transparent">
-                        {{ if .Site.IsMultiLingual }}
+                        {{ if hugo.IsMultilingual }}
                             {{- partial (printf "%s/%s" ($.Scratch.Get "pathName") "top-header.html") . -}}
                         {{ else }}
                             {{- partialCached (printf "%s/%s" ($.Scratch.Get "pathName") "top-header.html") . -}}

--- a/layouts/partials/docs/footer/footer-scripts.html
+++ b/layouts/partials/docs/footer/footer-scripts.html
@@ -49,7 +49,7 @@
 
 {{ $js := $slice | resources.Concat (printf "/%s/%s" ($.Scratch.Get "pathName") "js/bundle.js") -}}
 
-{{- if not .Site.IsServer }}
+{{- if not hugo.IsServer }}
     {{- $js := $js | minify | fingerprint "sha384" }}
     <script type="text/javascript" src="{{ $js.Permalink }}" integrity="{{ $js.Data.Integrity }}" crossorigin="anonymous" defer></script>
 {{- else }}

--- a/layouts/partials/docs/head.html
+++ b/layouts/partials/docs/head.html
@@ -100,7 +100,7 @@
     {{- end -}}
     <!-- Google Analytics v4 Config -->
     {{- if not hugo.IsServer }}
-    {{- if .Site.GoogleAnalytics }}
+    {{- if .Site.Config.Services.GoogleAnalytics.ID }}
         {{- template "_internal/google_analytics.html" . -}}
     {{- end -}}
     {{- end -}}

--- a/layouts/partials/docs/head.html
+++ b/layouts/partials/docs/head.html
@@ -42,7 +42,7 @@
         {{ if and (.Site.Params.docsearch.appID) (.Site.Params.docsearch.apiKey) -}}
         {{ else }}
             {{ $flexSearch := resources.Get (printf "/%s/%s" ($.Scratch.Get "pathName") "js/flexsearch.bundle.js") }}
-            {{- if not .Site.IsServer }}
+            {{- if not hugo.IsServer }}
                 {{ $flexSearch := $flexSearch | minify | fingerprint "sha384" }}
                 <script type="text/javascript" src="{{ $flexSearch.Permalink }}" integrity="{{ $flexSearch.Data.Integrity }}" crossorigin="anonymous"></script>
                 {{ else }}
@@ -58,7 +58,7 @@
         {{- $options := dict "enableSourceMap" false "outputStyle" "compressed" }}
     {{- end }}
     {{- $style := resources.Get (printf "/%s/%s" ($.Scratch.Get "pathName") "scss/style.scss") }}
-    {{- $style = $style | resources.ExecuteAsTemplate (printf "/%s/%s" ($.Scratch.Get "pathName") "scss/style.scss") . | resources.ToCSS $options }}
+    {{- $style = $style | resources.ExecuteAsTemplate (printf "/%s/%s" ($.Scratch.Get "pathName") "scss/style.scss") . | css.Sass $options }}
     {{- if hugo.IsProduction }}
         {{- $style = $style | minify | fingerprint "sha384" }}
     {{- end -}}
@@ -70,7 +70,7 @@
         {{- $options := dict "enableSourceMap" false "outputStyle" "compressed" }}
     {{- end -}}
     {{- $katexCSS := resources.Get (printf "/%s/%s" ($.Scratch.Get "pathName") "scss/katex.scss") }}
-    {{- $katexCSS = $katexCSS | resources.ExecuteAsTemplate (printf "/%s/%s" ($.Scratch.Get "pathName") "scss/katex.scss") . | resources.ToCSS $options }}
+    {{- $katexCSS = $katexCSS | resources.ExecuteAsTemplate (printf "/%s/%s" ($.Scratch.Get "pathName") "scss/katex.scss") . | css.Sass $options }}
     {{- if hugo.IsProduction }}
         {{- $katexCSS = $katexCSS | minify | fingerprint "sha384" }}
     {{- end -}}
@@ -93,13 +93,13 @@
         {{- partialCached (printf "%s/%s" ($.Scratch.Get "pathName") "footer/katex.html") . -}}
     {{ end }}
     <!-- Plausible Analytics Config -->
-    {{- if not .Site.IsServer }}
+    {{- if not hugo.IsServer }}
     {{ if and (.Site.Params.plausible.scriptURL | default "https://plausible.io") (.Site.Params.plausible.dataDomain) -}}
         {{- partialCached (printf "%s/%s" ($.Scratch.Get "pathName") "head/plausible") . }}
     {{- end -}}
     {{- end -}}
     <!-- Google Analytics v4 Config -->
-    {{- if not .Site.IsServer }}
+    {{- if not hugo.IsServer }}
     {{- if .Site.GoogleAnalytics }}
         {{- template "_internal/google_analytics.html" . -}}
     {{- end -}}

--- a/layouts/partials/docs/head/opengraph.html
+++ b/layouts/partials/docs/head/opengraph.html
@@ -42,4 +42,4 @@
 {{- end }}
 
 {{- /* Facebook Page Admin ID for Domain Insights */}}
-{{- with .Site.Social.facebook_admin }}<meta property="fb:admins" content="{{ . }}" />{{ end }}
+{{- with .Site.Params.Social.facebook_admin }}<meta property="fb:admins" content="{{ . }}" />{{ end }}

--- a/layouts/partials/docs/head/twitter_cards.html
+++ b/layouts/partials/docs/head/twitter_cards.html
@@ -18,6 +18,6 @@
 {{- end }}
 <meta name="twitter:title" content="{{ .Title }}"/>
 <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"/>
-{{ with .Site.Social.twitter -}}
+{{ with .Site.Params.Social.twitter -}}
 <meta name="twitter:site" content="@{{ . }}"/>
 {{ end -}}

--- a/layouts/partials/docs/top-header.html
+++ b/layouts/partials/docs/top-header.html
@@ -78,7 +78,7 @@
                 </span>
             </button>
             {{ end -}}
-            {{ if .Site.IsMultiLingual }}
+            {{ if hugo.IsMultilingual }}
                 <div class="dropdown">
                     <button class="btn btn-link btn-default dropdown-toggle ps-2" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                         {{ site.Language.Lang | upper }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -55,7 +55,7 @@
     {{- end -}}
     <!-- Google Analytics v4 Config -->
     {{- if not hugo.IsServer }}
-    {{- if .Site.GoogleAnalytics }}
+    {{- if .Site.Config.Services.GoogleAnalytics.ID }}
         {{- template "_internal/google_analytics.html" . -}}
     {{- end -}}
     {{- end -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -21,7 +21,7 @@
         {{- $options := dict "enableSourceMap" false "outputStyle" "compressed" }}
     {{- end }}
     {{- $style := resources.Get "/scss/style.scss" }}
-    {{- $style = $style | resources.ExecuteAsTemplate "/scss/style.scss" . | resources.ToCSS $options }}
+    {{- $style = $style | resources.ExecuteAsTemplate "/scss/style.scss" . | css.Sass $options }}
     {{- if hugo.IsProduction }}
         {{- $style = $style | minify | fingerprint "sha384" }}
     {{- end -}}
@@ -39,7 +39,7 @@
     <!-- Image Compare Viewer -->
     {{ if ($.Scratch.Get "image_compare_enabled") }}
         {{ $imagecompare := resources.Get "js/image-compare-viewer.min.js" }}
-        {{- if not .Site.IsServer }}
+        {{- if not hugo.IsServer }}
             {{- $js := (slice $imagecompare) | resources.Concat "/js/image-compare.js" | minify | fingerprint "sha384" }}
             <script type="text/javascript" src="{{ $js.Permalink }}" integrity="{{ $js.Data.Integrity }}"></script>
         {{- else }}
@@ -48,13 +48,13 @@
         {{- end }}
     {{- end }}
     <!-- Plausible Analytics Config -->
-    {{- if not .Site.IsServer }}
+    {{- if not hugo.IsServer }}
     {{ if and (.Site.Params.plausible.scriptURL) (.Site.Params.plausible.dataDomain) -}}
         {{- partialCached "head/plausible" . }}
     {{- end -}}
     {{- end -}}
     <!-- Google Analytics v4 Config -->
-    {{- if not .Site.IsServer }}
+    {{- if not hugo.IsServer }}
     {{- if .Site.GoogleAnalytics }}
         {{- template "_internal/google_analytics.html" . -}}
     {{- end -}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,4 +7,4 @@ command = "cd exampleSite && hugo --gc --minify --themesDir ../.. -b ${DEPLOY_PR
 ignore = "false"
 
 [build.environment]
-HUGO_VERSION = "0.120.4"
+HUGO_VERSION = "0.124.1"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,4 +7,4 @@ command = "cd exampleSite && hugo --gc --minify --themesDir ../.. -b ${DEPLOY_PR
 ignore = "false"
 
 [build.environment]
-HUGO_VERSION = "0.124.1"
+HUGO_VERSION = "0.142.0"

--- a/theme.toml
+++ b/theme.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/colinwilson/lotusdocs"
 demosite = "https://lotusdocs.dev/docs/"
 tags = ["documentation", "responsive", "bootstrap", "minimal", "secure", "search", "customizable", "modern","dark", "dark mode", "landing page"]
 features = ["security aware", "fast by default", "seo-ready","custom shortcodes", "prismjs syntax highlighting", "deploy to vercel", "flexsearch static search", "docsearch", "landing page layouts", "dark mode"]
-min_version = "0.124.0"
+min_version = "0.140.0"
 
 [author]
   name = "Colin Wilson"

--- a/theme.toml
+++ b/theme.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/colinwilson/lotusdocs"
 demosite = "https://lotusdocs.dev/docs/"
 tags = ["documentation", "responsive", "bootstrap", "minimal", "secure", "search", "customizable", "modern","dark", "dark mode", "landing page"]
 features = ["security aware", "fast by default", "seo-ready","custom shortcodes", "prismjs syntax highlighting", "deploy to vercel", "flexsearch static search", "docsearch", "landing page layouts", "dark mode"]
-min_version = "0.120.0"
+min_version = "0.124.0"
 
 [author]
   name = "Colin Wilson"


### PR DESCRIPTION
### Changes

When running example site with latest hugo version 0.138.0, preview fails with errors. This PR fixes all issues.
It also increases min hugo version to 0.124.0.

This PR is similar to #186, but goes beyond that PR (documentation, ...)
This PR fixes #191.

<!-- ### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests -->

<!-- ### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change -->

<!-- ### Documentation
- [x] [Docs](https://github.com/colinwilson/lotusdocs.dev) have been updated
- [ ] This change does not need a documentation update -->

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
