### PR TITLE
🐞 Remove deprecated `Site.GoogleAnalytics` #205/#204

### DIFF
--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -27,7 +27,7 @@
     {{ end }}
 
     {{ if .Site.Params.feedback.enabled | default false -}}
-        {{ if or (.Site.Params.plausible.dataDomain) (.Site.GoogleAnalytics) }}
+        {{ if or (.Site.Params.plausible.dataDomain) (.Site.Config.Services.GoogleAnalytics.ID) }}
             {{- partial (printf "%s/%s" ($.Scratch.Get "pathName") "footer/feedback.html") . -}}
         {{ else }}
             {{ errorf "Either Google Analytics or Plausible Analytics must be configured before enabling the Feedback Widget." }}

--- a/layouts/partials/docs/footer/feedback.html
+++ b/layouts/partials/docs/footer/feedback.html
@@ -253,7 +253,7 @@
         }
         try {
             if (formType == "positive") {
-                {{ if .Site.GoogleAnalytics -}}
+                {{ if .Site.Config.Services.GoogleAnalytics.ID -}}
                 {{ if not .Site.Params.feedback.eventDest | or (in .Site.Params.feedback.eventDest "google") -}}
                 gtag('event', '{{ replaceRE `( {1,})` "_" (.Site.Params.feedback.positiveEventName | default "Positive Feedback" | lower) }}',
                     {
@@ -279,7 +279,7 @@
                 {{ end -}}
                 {{ end -}}
             } else if (formType == "negative") {
-                {{ if .Site.GoogleAnalytics -}}
+                {{ if .Site.Config.Services.GoogleAnalytics.ID -}}
                 {{ if not .Site.Params.feedback.eventDest | or (in .Site.Params.feedback.eventDest "google") -}}
                 gtag('event', '{{ replaceRE `( {1,})` "_" (.Site.Params.feedback.negativeEventName | default "Positive Feedback" | lower) }}',
                     {


### PR DESCRIPTION
### Changes

Replace references to deprecated `Site.GoogleAnalytics`

<!-- ### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests -->

<!-- ### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change -->

<!-- ### Documentation
- [ ] [Docs](https://github.com/colinwilson/lotusdocs.dev) have been updated
- [ ] This change does not need a documentation update -->

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
