### PR TITLE
Fix: static image are not rendered

### DIFF
--- a/layouts/docs/_markup/render-image.html
+++ b/layouts/docs/_markup/render-image.html
@@ -29,5 +29,7 @@
     {{ else }}
       <img src="{{ .RelPermalink | safeURL }}" alt="{{ $text }}" width="{{ .Width }}" height="{{ .Height }}" loading="lazy">
     {{ end }}
+  {{ else }}
+    <img src="{{ .Destination | safeURL }}" alt="{{ $text }}" loading="lazy">
   {{ end }}
 {{ end }}


### PR DESCRIPTION
Fix static images with classical markdown notation were not rendered