### PR TITLE
Fix: better consistency text/code font size

### DIFF
--- a/assets/docs/scss/custom/structure/_content.scss
+++ b/assets/docs/scss/custom/structure/_content.scss
@@ -220,7 +220,7 @@ i {
 }
 
 .docs-content .main-content code {
-    font-size: inherit;
+    // font-size: inherit;
     // color: var(--text-default);
     font-weight: 400;
     padding: 1px 2px;


### PR DESCRIPTION
### Changes

I've updated the code block font size to avoid it being too big compared to the text. With this fix it's much more consistent as you can see on screenshots:

![screenshot_2025-04-11_14 28 19@2x](https://github.com/user-attachments/assets/8107bf8b-845e-4a00-ae7f-e45437e3ca53)

![screenshot_2025-04-11_14 29 09@2x](https://github.com/user-attachments/assets/393f7bba-18c0-4533-96ed-92773e9c4e44)
