### PR TITLE
feat: add lastmod support and fallback to git

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -87,6 +87,7 @@ defaultContentLanguage = 'en'
         editPage        = true                                # enable 'Edit this page' feature - default false
         lastMod         = true                                # enable 'Last modified' date on pages - default false
         lastModRelative = true                                # format 'Last modified' time as relative - default true
+        useLastmodTime  = false                               # use lastmod time for content or fallback to git info - default false
 
         sidebarIcons    = true                                # enable sidebar icons? default false
         breadcrumbs     = true                                # default is true

--- a/layouts/partials/docs/gitinfo.html
+++ b/layouts/partials/docs/gitinfo.html
@@ -22,25 +22,35 @@
     {{ if .Site.Params.docs.editPage | default false -}}
     <div id="edit-this-page" class="mt-1">
         <a href="{{ $editPageURL }}" alt="{{ .Title }}" rel="noopener noreferrer" target="_blank">
-            <!-- <span class="material-icons size-20 align-text-bottom text-primary">edit</span> -->
             <span class="me-1 align-text-bottom">
                 {{ with resources.Get $iconPath }}
                     {{ .Content | safeHTML }}
                 {{ end }}
             </span>
             Edit this page
-            <!-- <span class="material-icons size-20 align-text-bottom text-primary">open_in_new</span> -->
         </a>
     </div>
     {{ end }}
     {{ if .Site.Params.docs.lastMod | default false -}}
     <div id="last-modified" class="mt-1">
-        <p class="mb-0 fw-semibold">Last updated <span
-            {{ if .Site.Params.docs.lastModRelative | default true -}}id="relativetime"{{ else }}{{ end }}
-            data-authdate="{{ dateFormat "2006-01-02T15:04:05Z0700" .GitInfo.AuthorDate }}"
-            {{ if .Site.Params.docs.lastModRelative | default true -}}title="{{ dateFormat "02 Jan 2006, 15:04 MST" .GitInfo.AuthorDate }}"{{ else }}{{ end }}>
-            {{ dateFormat "02 Jan 2006, 15:04 MST" .GitInfo.AuthorDate }}
-        </span>. <span class="material-icons size-20 align-text-bottom opacity-75">history</span>
+        <p class="mb-0 fw-semibold">Last updated 
+            <span 
+                {{- if .Site.Params.docs.lastModRelative | default true }} id="relativetime"{{ end }}
+                {{- if .Params.lastmod }}
+                    data-authdate="{{ dateFormat "2006-01-02T15:04:05Z0700" .Params.lastmod }}"
+                {{- else if and (.Site.Params.docs.useLastmodTime | default false) (.Lastmod) }}
+                    data-authdate="{{ dateFormat "2006-01-02T15:04:05Z0700" .Lastmod }}"
+                {{- else }}
+                    data-authdate="{{ dateFormat "2006-01-02T15:04:05Z0700" .GitInfo.AuthorDate }}"
+                {{- end }}>
+                {{- if .Params.lastmod -}}
+                    {{ dateFormat "02 Jan 2006, 15:04 MST" .Params.lastmod }}
+                {{- else if and (.Site.Params.docs.useLastmodTime | default false) (.Lastmod) -}}
+                    {{ dateFormat "02 Jan 2006, 15:04 MST" .Lastmod }}
+                {{- else -}}
+                    {{ dateFormat "02 Jan 2006, 15:04 MST" .GitInfo.AuthorDate }}
+                {{- end -}}
+            </span>. <span class="material-icons size-20 align-text-bottom opacity-75">history</span>
         </p>
     </div>
     {{ end }}


### PR DESCRIPTION
### Changes

The date of an article can now use lastmod info:
* If present use it as the last update
* If absent, fallback to git date Configurable with a new option: useLastmodTime

<!-- ### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests -->

<!-- ### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change -->

<!-- ### Documentation
- [ ] [Docs](https://github.com/colinwilson/lotusdocs.dev) have been updated
- [ ] This change does not need a documentation update -->

### Dark mode
- [X] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
