### PR TITLE
Feat: Enable/Disable Landing Page

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -58,6 +58,9 @@ defaultContentLanguage = 'en'
   secondary_font  = "Inter"     # Default is System font
   mono_font       = "Fira Code" # Default is System font
 
+    [params.landingpage]
+        enabled = true # (optional) - Set to 'false' to disable the landing page (default is true)
+
     [params.footer]
         copyright = "© :YEAR: Lotus Labs. Built with [**Lotus Docs**](https://github.com/colinwilson/lotusdocs)"
         # version = true # includes git commit info

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,24 +1,22 @@
-{{ define "main" }}
-    {{ $landingData := .Site.Data.landing }}
-    {{ $map := newScratch }}
-
-    {{ range $key, $value := $landingData }}
-        {{ $sectionTitle := (index $key) }}
-        {{ $weight := string ($value.weight) }}
-        {{ $template := string (replaceRE `( |-{1,})` "_" $value.template) }}
-        {{ with and $template $weight }}
-            {{ $map.SetInMap "wgtTpl" $sectionTitle (dict
-            "weight" $weight
-            "template" $template
-            "sectionTitle" $sectionTitle
-            )}}
-        {{ end }}
-    {{ end }}
-
-    {{ range sort ($map.Get "wgtTpl") ".weight" }}
-        {{ $.Scratch.Set "sectionTitle" .sectionTitle }}
-        {{ $path := printf "landing/%s.html" .template }}
-        {{ partial $path $.Page }}
-    {{ end }}
-    {{/* printf "%s" (sort ($map.Get "wgtTpl") ".weight" ) */}}
-{{ end }}
+{{- define "main" -}}
+    {{- $landingPageEnabled := .Site.Params.landingpage.enabled | default true -}}
+    {{- if not $landingPageEnabled -}}
+        <script>
+            window.location.href = "/docs/";
+        </script>
+    {{- else -}}
+        {{- $landingData := .Site.Data.landing -}}
+        {{- $sections := slice -}}
+        {{- range $sectionTitle, $value := $landingData -}}
+            {{- $weight := printf "%v" $value.weight -}}
+            {{- $template := replaceRE `( |-{1,})` "_" $value.template -}}
+            {{- $section := dict "sectionTitle" $sectionTitle "weight" $weight "template" $template -}}
+            {{- $sections = $sections | append $section -}}
+        {{- end -}}
+        {{- $sortedSections := sort $sections "weight" -}}
+        {{- range $sortedSections -}}
+            {{- $.Scratch.Set "sectionTitle" .sectionTitle -}}
+            {{- partial (printf "landing/%s.html" .template) $.Page -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}


### PR DESCRIPTION
## PR: Enable or disable the landing page via configuration

### ✨ Feature: Toggle for the landing page

This change introduces a new configuration option in `hugo.toml` that allows you to easily enable or disable the landing page. It adds flexibility for environments where a direct redirect to `/docs/` is preferred.

#### 🔧 Added configuration

**Enable landing page (default)** No action required. The landing page will be shown as usual.

```toml
[params.landingpage]
  enabled = true # Default value: true
```

**Disable landing page** Set `enabled` to `false`. Visitors will then be automatically redirected to `/docs/`.

```toml
[params.landingpage]
  enabled = false
```

#### 🛠 Updated logic

The logic in `layouts/index.html` has been updated to check whether the landing page is disabled. If `enabled = false`, it performs an automatic redirect to `/docs/`. Otherwise, the landing page is rendered based on the data in `data/landing.yaml`.

### ✅ Changes

- [x] Added new `landingpage.enabled` parameter to `hugo.toml`
- [x] Conditional rendering in `layouts/index.html` based on this parameter
- [x] Redirect to `/docs/` if landing page is disabled

### 🔍 Checklist

- [x] Code tested and works as expected
- [x] No new errors or warnings
- [x] No additional documentation required (the configuration is self-explanatory)

### 🎨 Dark mode

- [x] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI (by default NO)

### 🔗 Related Issues and/or Discussions

#### Issues

- Resolves #170

#### Discussions

- Relates to #137
- Relates to #147
- Relates to #224