### PR TITLE
Fix: cards with link light theme issue

### DIFF
--- a/assets/docs/scss/custom/pages/_features.scss
+++ b/assets/docs/scss/custom/pages/_features.scss
@@ -14,6 +14,11 @@
     --feature-link-hover-bg-color: var(--gray-900);
 }
 
+// Light theme only - Fix for card links making them white on hover
+html:not([data-dark-mode]) .features.feature-full-bg:hover a {
+    color: var(--white) !important;
+}
+
 .features {
     .icon {
         background: rgba(var(--primary), 0.1);


### PR DESCRIPTION
### Changes

I fixed (maybe not the best way), the cards with links issues as described in the lotusdocs overview: https://lotusdocs.dev/docs/overview/

When links are used, here is what it looks light in dark and light theme, only light has an issue:
![screenshot_2025-04-21_13 57 01@2x](https://github.com/user-attachments/assets/d1684519-4223-4b7d-9c39-f52613e64a59)
![screenshot_2025-04-21_13 57 17@2x](https://github.com/user-attachments/assets/06841075-c884-4a0f-a81b-f84788fa86b6)
![screenshot_2025-04-21_13 57 32@2x](https://github.com/user-attachments/assets/9ee441bb-79ff-4f6b-912b-c2bc8512f3a8)
![screenshot_2025-04-21_13 57 51@2x](https://github.com/user-attachments/assets/113cbbcc-d870-4fad-9259-773c6669a607)

With the fix, here is the result on the light theme:
![screenshot_2025-04-21_13 58 52@2x](https://github.com/user-attachments/assets/2579612d-0720-4688-9a67-ecf3fa79e364)


### Dark mode
- [X] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
