### PR TITLE
Updated: CodeQL workflow to use latest action versions

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -30,13 +30,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive # Fetch submodules
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -47,7 +47,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl


### PR DESCRIPTION
## PR: Update CodeQL Workflow to Use v3 Actions

### Summary

This PR updates the `codeql-analysis.yaml` workflow to address the deprecation of CodeQL Action v2 by upgrading to v3.

### 🔧 Changes Made

- Upgraded `github/codeql-action/init` from `v2` to `v3`.
- Upgraded `github/codeql-action/autobuild` from `v2` to `v3`.
- Updated `actions/checkout` from `v3` to `v4`.
- Switched `runs-on` from `ubuntu-20.04` to `ubuntu-latest` for improved compatibility and longevity.

### 📌 Motivation

GitHub announced the deprecation of CodeQL Action v2. To ensure continued support and security scanning functionality, this workflow has been updated accordingly.

> 🔗 [GitHub Changelog: Deprecation of CodeQL Action v2](https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/)

### 🔍 Checklist

- [x] Verified updated workflow syntax.
- [x] Confirmed CI still passes with updated actions.