### PR TITLE
feat: add custom home breadcrum link config

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -90,6 +90,7 @@ defaultContentLanguage = 'en'
 
         sidebarIcons    = true                                # enable sidebar icons? default false
         breadcrumbs     = true                                # default is true
+        breadcrumbsHomeLink = "/docs/"
         backToTop       = true                                # enable back-to-top button? default true
 
         # ToC

--- a/layouts/partials/docs/breadcrumbs.html
+++ b/layouts/partials/docs/breadcrumbs.html
@@ -7,7 +7,7 @@
                 <li class="breadcrumb-item text-capitalize active" aria-current="page" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
                     {{- $data.Set "counter" $index }}
                     {{- $data.Add "counter" 1 }}
-                    <a itemprop="item" href="{{ .RelPermalink }}">
+                    <a itemprop="item" href="{{ with site.Params.docs.breadcrumbsHomeLink }}{{ . }}{{ else }}{{ .RelPermalink }}{{ end }}">
                         <i class="material-icons size-20 align-text-bottom" itemprop="name">Home</i>
                     </a>
                     <meta itemprop="position" content='{{ $data.Get "counter"}}' />


### PR DESCRIPTION
### Changes

As /docs/ is mandatory, if you don't need the home page but want to use breadcrumb, here is a simple solution to set the homepage
