### PR TITLE
Update mermaid background

### DIFF
--- a/assets/docs/scss/custom/components/_backgrounds.scss
+++ b/assets/docs/scss/custom/components/_backgrounds.scss
@@ -6,12 +6,14 @@
     --bg-default: hsl(var(--primary-800-hsl),0.1);
     --bg-default-border: hsl(var(--primary-800-hsl),0.1);
     --bg-default-color: var(--text-default);
+    --bg-mermaid: var(--gray-100);
 }
 
 [data-dark-mode] {
     --bg-default: var(--gray-800);
     --bg-default-border: hsl(var(--primary-200-hsl),0.1);
     --bg-default-color: var(--text-default);
+    --bg-mermaid: var(--gray-800);
 }
 
 .bg-default {

--- a/assets/docs/scss/custom/plugins/mermaid/_mermaid.scss
+++ b/assets/docs/scss/custom/plugins/mermaid/_mermaid.scss
@@ -37,5 +37,12 @@
         text {
             fill: var(--text-default) !important;
         }
+        #sequencenumber circle {
+            fill: var(--bg-mermaid) !important;
+            stroke: var(--text-default) !important;
+        }
+        .sequenceNumber {
+            fill: var(--text-default) !important;
+        }
     }
 }

--- a/exampleSite/content/docs/example-content/mermaid.md
+++ b/exampleSite/content/docs/example-content/mermaid.md
@@ -24,6 +24,7 @@ C -->|Two| E[Result 2]
 
 ```mermaid
 sequenceDiagram
+autonumber
 Alice->>John: Hello John, how are you?
 loop Healthcheck
     John->>John: Fight against hypochondria


### PR DESCRIPTION
### Changes

In sequence diagrams, if you add numbering, the background circle was too dark to read the numbers in light mode. See screenshots below.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change 

I am not sure whether this needs a changelog entry or where to do that.

### Documentation
- [x] [Docs](https://github.com/colinwilson/lotusdocs.dev) have been updated --> I updated the sample site to add numbering to the sample mermaid sequence diagram
- [ ] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI

### Light mode before
<img width="868" alt="image" src="https://github.com/user-attachments/assets/637eacd3-ed21-4c8d-b92f-9aadeb06756f" />

### Dark mode before

<img width="856" alt="image" src="https://github.com/user-attachments/assets/96e1ee42-dd85-4ba3-81e9-acae8fda8908" />


### Light mode now
<img width="871" alt="image" src="https://github.com/user-attachments/assets/caadaae6-8631-4218-be16-36b2ab9a0c01" />


### Dark mode now
<img width="847" alt="image" src="https://github.com/user-attachments/assets/e0b1872c-d456-48f1-8443-fd19d8b495c7" />

