### PR TITLE
Feat: meta-tags are now configurable

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,3 +5,12 @@
   [[module.imports]]
     path = "github.com/gohugoio/hugo-mod-bootstrap-scss/v5"
     disable = false
+
+[params]
+    [params.head]
+        author = "Colin Wilson - Lotus Labs"
+        description = "A Lightweight, Modern Documentation Theme for Hugo"
+        keywords = "Documentation, Hugo, Hugo Theme, Bootstrap"
+        email = "support@aigis.uk"
+        website = "https://lotusdocs.dev"
+        version = "v0.1.0"

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -58,6 +58,14 @@ defaultContentLanguage = 'en'
   secondary_font  = "Inter"     # Default is System font
   mono_font       = "Fira Code" # Default is System font
 
+    [params.head] # Use these to override the default meta-tags in the page headers
+        # author = "Colin Wilson - Lotus Labs"
+        # description = "A Lightweight, Modern Documentation Theme for Hugo"
+        # keywords = "Documentation, Hugo, Hugo Theme, Bootstrap"
+        # email = "support@aigis.uk"
+        # website = "https://lotusdocs.dev"
+        # version = "v0.1.0"
+
     [params.footer]
         copyright = "© :YEAR: Lotus Labs. Built with [**Lotus Docs**](https://github.com/colinwilson/lotusdocs)"
         # version = true # includes git commit info

--- a/layouts/partials/docs/head.html
+++ b/layouts/partials/docs/head.html
@@ -20,14 +20,25 @@
     <meta name="robots" content="noindex">
     {{- end }}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    {{- with .Description | default ($.Param "description") }}
+
+    {{- with .Description | default (.Site.Params.head.description) }}
     <meta name="description" content="{{ . }}">
     {{- end }}
-    <meta name="keywords" content="Documentation, Hugo, Hugo Theme, Bootstrap" />
-    <meta name="author" content="Colin Wilson - Lotus Labs" />
-    <meta name="email" content="support@aigis.uk" />
-    <meta name="website" content="https://lotusdocs.dev" />
-    <meta name="Version" content="v0.1.0" />
+    {{- with .Params.keywords | default (.Site.Params.head.keywords)}}
+    <meta name="keywords" content="{{.}}" />
+    {{- end }}
+    {{- with .Params.author | default (.Site.Params.head.author)}}
+    <meta name="author" content="{{.}}" />
+    {{- end }}
+    {{- with .Params.email | default (.Site.Params.head.email)}}
+    <meta name="email" content="{{.}}" />
+    {{- end }}
+    {{- with .Params.website | default (.Site.Params.head.website)}}
+    <meta name="website" content="{{.}}" />
+    {{- end }}
+    {{- with .Params.version | default (.Site.Params.head.version)}}
+    <meta name="Version" content="{{.}}" />
+    {{- end }}
     <!-- favicon -->
     {{ block "favicon" . }}{{ partialCached (printf "%s/%s" ($.Scratch.Get "pathName") "head/favicon.html") . }}{{ end }}
     {{- partial (printf "%s/%s" ($.Scratch.Get "pathName") "head/opengraph") . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,12 +5,12 @@
     <meta name="robots" content="noindex">
     {{- end }}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="A Lightweight, Modern Documentation Theme for Hugo" />
-    <meta name="keywords" content="Documentation, Hugo, Hugo Theme, Bootstrap" />
-    <meta name="author" content="Colin Wilson - Lotus Labs" />
-    <meta name="email" content="support@aigis.uk" />
-    <meta name="website" content="https://lotusdocs.dev" />
-    <meta name="Version" content="v0.1.0" />
+    <meta name="description" content="{{ .Site.Params.head.description }}" />
+    <meta name="keywords" content="{{ .Site.Params.head.keywords}}" />
+    <meta name="author" content="{{ .Site.Params.head.author }}" />
+    <meta name="email" content="{{ .Site.Params.head.email}}" />
+    <meta name="website" content="{{ .Site.Params.head.website}}" />
+    <meta name="Version" content="{{ .Site.Params.head.version}}" />
     <!-- favicon -->
     {{ block "head/favicon" . }}{{ partialCached "head/favicon.html" . }}{{ end }}
     <!-- Google Fonts -->


### PR DESCRIPTION
### Changes
Added a new params.head section to the theme config.toml with the default values for meta-tags. The user can override these in their hugo.toml file.

For individual docs pages, the meta-tags will use front-mater values first, then fall back to site defaults if they have not been set

This PR resolves https://github.com/colinwilson/lotusdocs/issues/243
