### PR TITLE
feat support arrowUp from suggestion to search element

### DIFF
--- a/layouts/partials/docs/footer/flexsearch.html
+++ b/layouts/partials/docs/footer/flexsearch.html
@@ -66,8 +66,12 @@
 
     if (e.key === "ArrowUp") {
         e.preventDefault();
-        const nextIndex = index > 0 ? index - 1 : 0;
-        focusableSuggestions[nextIndex].focus();
+        const nextIndex = index >= 0 ? index - 1 : 0;
+        if (nextIndex === -1) {
+            search.focus()
+        } else {
+            focusableSuggestions[nextIndex].focus();
+        }
     }
     else if (e.key === "ArrowDown") {
         e.preventDefault();


### PR DESCRIPTION
### Changes

When in suggestion, once I arrow down to select index, I couldn't back to search element by keyboard only. I must use mouse and it is strange.

So I make a little change to make it possible

- [x] This PR does not require tests
- [x] I don't know where is changelog
- [x] This change does not need a documentation update
- [x] This PR does not change the UI
