### PR TITLE
Fix KaTeX square root SVG rendering in docs content

### DIFF
--- a/assets/docs/scss/custom/plugins/katex/_katex.scss
+++ b/assets/docs/scss/custom/plugins/katex/_katex.scss
@@ -1178,6 +1178,10 @@
   stroke-opacity: 1;
 }
 
+.docs-content .main-content .katex svg {
+  height: inherit;
+}
+
 .katex svg path {
   stroke: none;
 }


### PR DESCRIPTION
## Summary

This fixes an issue where KaTeX square roots can render incorrectly in docs pages.

For example, a page with KaTeX enabled and the following formula:

```tex
$\sqrt{5}$
```

is parsed and rendered by KaTeX, but the radical sign is visually collapsed. The page may show only the `5`, or the root symbol may appear as an almost invisible line.

## Root cause

Lotus Docs applies a general content rule to images and SVGs:

```scss
.docs-content .main-content {
  img,
  svg {
    max-width: 100%;
    height: auto;
  }
}
```

KaTeX uses SVGs for stretchy math elements, including the radical symbol in `\sqrt`. KaTeX expects those SVGs to keep:

```scss
.katex svg {
  height: inherit;
}
```

However, the Lotus Docs selector is more specific than `.katex svg`, so `height: auto` wins inside docs content. In a minimal reproduction, the `$\sqrt{5}$` SVG was present in the DOM, but its rendered height was only about `0.078px`, making the radical effectively invisible.

## Impact

The confirmed visible issue is that `\sqrt` formulas may not display the radical sign correctly.

The same CSS conflict may also affect other KaTeX features that rely on stretchy SVG elements, such as long arrows, over/under braces, delimiters, or similar extensible symbols. I have only verified the square-root case directly.

## Changes

Adds a docs-content-scoped KaTeX override:

```scss
.docs-content .main-content .katex svg {
  height: inherit;
}
```

This keeps the general docs SVG behavior intact while restoring KaTeX's expected SVG height handling inside rendered formulas.

## Validation

- Built the example site with `hugo --source exampleSite --destination /private/tmp/lotusdocs-build-check`
- Verified a minimal Hugo site using Lotus Docs renders `$\sqrt{5}$` correctly after the change
- In the minimal repro, the square-root SVG height changed from about `0.078px` before the fix to about `27.64px` after the fix
