### PR TITLE
feat: Added devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,44 @@
+FROM debian:bookworm-slim
+
+ARG HUGO_VERSION=0.140.0
+ARG GO_VERSION=1.21.0
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=1000
+
+# Detect architecture for cross-platform support
+RUN ARCH="$(dpkg --print-architecture)" && echo "Building for ${ARCH}"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Go
+RUN ARCH="$(dpkg --print-architecture)" \
+    && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" \
+    | tar -C /usr/local -xz
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Install Hugo Extended
+RUN ARCH="$(dpkg --print-architecture)" \
+    && curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${ARCH}.tar.gz" \
+    | tar -C /usr/local/bin -xz hugo
+
+# Create non-root user
+RUN groupadd --gid ${USER_GID} ${USERNAME} \
+    && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} \
+    && echo "${USERNAME} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME} \
+    && chmod 0440 /etc/sudoers.d/${USERNAME}
+
+# Fix ARG scope - re-declare so it's visible to ENV
+ARG USERNAME=vscode
+ENV GOPATH="/home/${USERNAME}/go"
+ENV GOMODCACHE="/home/${USERNAME}/go/pkg/mod"
+ENV PATH="/home/${USERNAME}/go/bin:/usr/local/go/bin:${PATH}"
+
+USER ${USERNAME}
+WORKDIR /workspaces/lotusdocs

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "Lotus Docs",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "HUGO_VERSION": "0.140.0",
+      "GO_VERSION": "1.21.0"
+    }
+  },
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/lotusdocs,type=bind,consistency=cached",
+  "workspaceFolder": "/workspaces/lotusdocs",
+  "containerUser": "vscode",
+  "remoteUser": "vscode",
+  "forwardPorts": [1313],
+  "portsAttributes": {
+    "1313": {
+      "label": "Hugo Development Server - Lotus Docs",
+      "onAutoForward": "openPreview"
+    }
+  },
+  "postCreateCommand": "hugo mod get",
+  "postAttachCommand": "hugo server --bind 0.0.0.0 --port 1313 --buildDrafts --buildFuture --disableFastRender --navigateToChanged",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Changes

Adds a dev container configuration for contributors using VS Code with either Docker or Podman.

The setup includes:
- A `Dockerfile` based on `debian:bookworm-slim` that installs Hugo Extended and Go at the minimum versions required by Lotus Docs (Hugo ≥ 0.140.0, Go ≥ 1.21.0)
- Architecture detection so the container builds correctly on both `amd64` and `arm64` machines (Intel/AMD and Apple Silicon)
- A non-root `vscode` user matching the devcontainer convention
- `devcontainer.json` configured to run `hugo mod get` on first create and start a Hugo server automatically on attach, with port 1313 forwarded

<img width="2121" height="1358" alt="image" src="https://github.com/user-attachments/assets/6b8d4c39-5311-4e36-b3b4-1a185a70b6a1" />

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/colinwilson/lotusdocs.dev) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
